### PR TITLE
Pictures folder crashing

### DIFF
--- a/720p/MyPics.xml
+++ b/720p/MyPics.xml
@@ -3,7 +3,7 @@
 	<defaultcontrol always="true">50</defaultcontrol>
 	<allowoverlay>no</allowoverlay>
 	<views>50,51,550,551,500,514,510</views>
-	<onload condition="!StringCompare(Container.FolderName,Pictures)">ReplaceWindow(pictures,Pictures)</onload>
+	<!--<onload condition="!StringCompare(Container.FolderName,Pictures)">ReplaceWindow(pictures,Pictures)</onload>-->
 	<!--library://video/files.xml/-->
 	<onunload>ClearProperty(SideBladeOpen)</onunload>
 	<controls>


### PR DESCRIPTION
Something wrong with this line. While it not commented Kodi crashing. I'am do not completely understand why need onload override default window, but without it "Pictures" category work again.