### PR TITLE
Conditional visibility of menu items on home screen based on master mode settings.

### DIFF
--- a/720p/IncludesMainMenu.xml
+++ b/720p/IncludesMainMenu.xml
@@ -326,6 +326,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.1.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.1.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.1.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.1.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.1.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.1.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.1.Master) | [Skin.HasSetting(HomeItem.1.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="2">
 				<description>Home Menu Item Two</description>
@@ -348,6 +349,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.2.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.2.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.2.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.2.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.2.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.2.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.2.Master) | [Skin.HasSetting(HomeItem.2.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="3">
 				<description>Home Menu Item Three</description>
@@ -370,6 +372,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.3.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.3.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.3.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.3.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.3.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.3.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.3.Master) | [Skin.HasSetting(HomeItem.3.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="4">
 				<description>Home Menu Item Four</description>
@@ -392,6 +395,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.4.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.4.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.4.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.4.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.4.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.4.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.4.Master) | [Skin.HasSetting(HomeItem.4.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="5">
 				<description>Home Menu Item Five</description>
@@ -414,6 +418,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.5.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.5.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.5.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.5.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.5.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.5.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.5.Master) | [Skin.HasSetting(HomeItem.5.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="6">
 				<description>Home Menu Item Six</description>
@@ -436,6 +441,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.6.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.6.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.6.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.6.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.6.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.6.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.6.Master) | [Skin.HasSetting(HomeItem.6.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="7">
 				<description>Home Menu Item Seven</description>
@@ -458,6 +464,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.7.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.7.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.7.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.7.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.7.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.7.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.7.Master) | [Skin.HasSetting(HomeItem.7.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="8">
 				<description>Home Menu Item Eight</description>
@@ -480,6 +487,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.8.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.8.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.8.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.8.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.8.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.8.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.8.Master) | [Skin.HasSetting(HomeItem.8.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="9">
 				<description>Home Menu Item Nine</description>
@@ -502,6 +510,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.9.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.9.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.9.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.9.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.9.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.9.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.9.Master) | [Skin.HasSetting(HomeItem.9.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="10">
 				<description>Home Menu Item Ten</description>
@@ -524,6 +533,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.10.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.10.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.10.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.10.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.10.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.10.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.10.Master) | [Skin.HasSetting(HomeItem.10.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="11">
 				<description>Home Menu Item Eleven</description>
@@ -546,6 +556,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.11.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.11.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.11.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.11.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.11.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.11.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.11.Master) | [Skin.HasSetting(HomeItem.11.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="12">
 				<description>Home Menu Item Twelve</description>
@@ -568,6 +579,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.12.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.12.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.12.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.12.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.12.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.12.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.12.Master) | [Skin.HasSetting(HomeItem.12.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="13">
 				<description>Home Menu Item Thirteen</description>
@@ -590,6 +602,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.13.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.13.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.13.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.13.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.13.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.13.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.13.Master) | [Skin.HasSetting(HomeItem.13.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="14">
 				<description>Home Menu Item Fourteen</description>
@@ -612,6 +625,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.14.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.14.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.14.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.14.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.14.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.14.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.14.Master) | [Skin.HasSetting(HomeItem.14.Master) + System.IsMaster]</visible>
 			</item>
 			<item id="15">
 				<description>Home Menu Item Fifteen</description>
@@ -634,6 +648,7 @@
 				<visible>!String.IsEqual(Skin.String(HomeItem.15.Type),Radio) | [String.IsEqual(Skin.String(HomeItem.15.Type),Radio) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.15.Type),LiveTV) | [String.IsEqual(Skin.String(HomeItem.15.Type),LiveTV) + !Skin.HasSetting(DisablePVRinView)]</visible>
 				<visible>!String.IsEqual(Skin.String(HomeItem.15.Type),PlayDisc) | [String.IsEqual(Skin.String(HomeItem.15.Type),PlayDisc) + System.HasMediaDVD]</visible>
+				<visible>!Skin.HasSetting(HomeItem.15.Master) | [Skin.HasSetting(HomeItem.15.Master) + System.IsMaster]</visible>
 			</item>
 		</content>
 	</include>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -1700,7 +1700,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -1851,7 +1851,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2002,7 +2002,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2153,7 +2153,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2304,7 +2304,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2455,7 +2455,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2606,7 +2606,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2757,7 +2757,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -2908,7 +2908,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3059,7 +3059,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3210,7 +3210,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3361,7 +3361,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3512,7 +3512,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3663,7 +3663,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>
@@ -3814,7 +3814,7 @@
 								<height>40</height>
 								<font>font13</font>
 								<align>left</align>
-								<label> - $LOCALIZE[12360]</label>
+								<label> - $LOCALIZE[32000]</label>
 								<textcolor>grey2</textcolor>
 								<focusedcolor>white</focusedcolor>
 								<include>MenuButton</include>

--- a/720p/SkinSettings.xml
+++ b/720p/SkinSettings.xml
@@ -1695,6 +1695,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.1.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1208">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.1.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.1.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.1.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -1831,6 +1844,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.2.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.2.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.2.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1218">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.2.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.2.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.2.Label))</visible>
 							</control>
 						</control>
@@ -1971,6 +1997,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.3.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1228">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.3.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.3.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.3.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -2107,6 +2146,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.4.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.4.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.4.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1238">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.4.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.4.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.4.Label))</visible>
 							</control>
 						</control>
@@ -2247,6 +2299,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.5.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1248">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.5.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.5.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.5.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -2383,6 +2448,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.6.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.6.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.6.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1258">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.6.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.6.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.6.Label))</visible>
 							</control>
 						</control>
@@ -2523,6 +2601,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.7.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1268">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.7.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.7.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.7.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -2659,6 +2750,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.8.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.8.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.8.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1278">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.8.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.8.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.8.Label))</visible>
 							</control>
 						</control>
@@ -2799,6 +2903,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.9.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1288">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.9.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.9.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.9.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -2935,6 +3052,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.10.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.10.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.10.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1298">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.10.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.10.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.10.Label))</visible>
 							</control>
 						</control>
@@ -3075,6 +3205,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.11.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1308">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.11.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.11.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.11.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -3211,6 +3354,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.12.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.12.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.12.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1318">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.12.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.12.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.12.Label))</visible>
 							</control>
 						</control>
@@ -3351,6 +3507,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.13.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1328">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.13.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.13.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.13.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -3489,6 +3658,19 @@
 								<onclick>ActivateWindow(1128)</onclick>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.14.Label))</visible>
 							</control>
+							<control type="radiobutton" id="1338">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.14.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.14.Master)</selected>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.14.Label))</visible>
+							</control>
 						</control>
 						<control type="image">
 							<left>80r</left>
@@ -3625,6 +3807,19 @@
 								<onclick>SetProperty(SwapItemDisplay,$INFO[Skin.String(HomeItem.15.Display)],Home)</onclick>
 								<onclick>SetProperty(SwapItemPlaylist,$INFO[Skin.String(HomeItem.15.Playlist)],Home)</onclick>
 								<onclick>ActivateWindow(1128)</onclick>
+								<visible>!String.IsEmpty(Skin.String(HomeItem.15.Label))</visible>
+							</control>
+							<control type="radiobutton" id="1348">
+								<width>750</width>
+								<height>40</height>
+								<font>font13</font>
+								<align>left</align>
+								<label> - $LOCALIZE[12360]</label>
+								<textcolor>grey2</textcolor>
+								<focusedcolor>white</focusedcolor>
+								<include>MenuButton</include>
+								<onclick>Skin.ToggleSetting(HomeItem.15.Master)</onclick>
+								<selected>Skin.HasSetting(HomeItem.15.Master)</selected>
 								<visible>!String.IsEmpty(Skin.String(HomeItem.15.Label))</visible>
 							</control>
 						</control>	

--- a/language/resource.language.af_za/strings.po
+++ b/language/resource.language.af_za/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.am_et/strings.po
+++ b/language/resource.language.am_et/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ar_sa/strings.po
+++ b/language/resource.language.ar_sa/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.az_az/strings.po
+++ b/language/resource.language.az_az/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.be_by/strings.po
+++ b/language/resource.language.be_by/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.bg_bg/strings.po
+++ b/language/resource.language.bg_bg/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.bs_ba/strings.po
+++ b/language/resource.language.bs_ba/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ca_es/strings.po
+++ b/language/resource.language.ca_es/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.cs_cz/strings.po
+++ b/language/resource.language.cs_cz/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.cy_gb/strings.po
+++ b/language/resource.language.cy_gb/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.da_dk/strings.po
+++ b/language/resource.language.da_dk/strings.po
@@ -1989,3 +1989,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.de_de/strings.po
+++ b/language/resource.language.de_de/strings.po
@@ -1987,3 +1987,7 @@ msgstr "Zuletzt hinzugefügt"
 msgctxt "#31999"
 msgid "Resolution"
 msgstr "Auflösung"
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr "Nur im Mastermodus sichtbar"

--- a/language/resource.language.el_gr/strings.po
+++ b/language/resource.language.el_gr/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.en_au/strings.po
+++ b/language/resource.language.en_au/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2077,3 +2077,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.en_nz/strings.po
+++ b/language/resource.language.en_nz/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -1987,3 +1987,7 @@ msgstr "Recently added"
 msgctxt "#31999"
 msgid "Resolution"
 msgstr "Resolution"
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr "Visible in Master mode only"

--- a/language/resource.language.eo/strings.po
+++ b/language/resource.language.eo/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.es_ar/strings.po
+++ b/language/resource.language.es_ar/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.es_es/strings.po
+++ b/language/resource.language.es_es/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.es_mx/strings.po
+++ b/language/resource.language.es_mx/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.et_ee/strings.po
+++ b/language/resource.language.et_ee/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.eu_es/strings.po
+++ b/language/resource.language.eu_es/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fa_af/strings.po
+++ b/language/resource.language.fa_af/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fa_ir/strings.po
+++ b/language/resource.language.fa_ir/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fi_fi/strings.po
+++ b/language/resource.language.fi_fi/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fo_fo/strings.po
+++ b/language/resource.language.fo_fo/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fr_ca/strings.po
+++ b/language/resource.language.fr_ca/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.fr_fr/strings.po
+++ b/language/resource.language.fr_fr/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.gl_es/strings.po
+++ b/language/resource.language.gl_es/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.he_il/strings.po
+++ b/language/resource.language.he_il/strings.po
@@ -2007,3 +2007,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.hi_in/strings.po
+++ b/language/resource.language.hi_in/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.hr_hr/strings.po
+++ b/language/resource.language.hr_hr/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.hu_hu/strings.po
+++ b/language/resource.language.hu_hu/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.hy_am/strings.po
+++ b/language/resource.language.hy_am/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.id_id/strings.po
+++ b/language/resource.language.id_id/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.is_is/strings.po
+++ b/language/resource.language.is_is/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ja_jp/strings.po
+++ b/language/resource.language.ja_jp/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ko_kr/strings.po
+++ b/language/resource.language.ko_kr/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.lt_lt/strings.po
+++ b/language/resource.language.lt_lt/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.lv_lv/strings.po
+++ b/language/resource.language.lv_lv/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.mi/strings.po
+++ b/language/resource.language.mi/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.mk_mk/strings.po
+++ b/language/resource.language.mk_mk/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ml_in/strings.po
+++ b/language/resource.language.ml_in/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.mn_mn/strings.po
+++ b/language/resource.language.mn_mn/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ms_my/strings.po
+++ b/language/resource.language.ms_my/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.mt_mt/strings.po
+++ b/language/resource.language.mt_mt/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.my_mm/strings.po
+++ b/language/resource.language.my_mm/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.nb_no/strings.po
+++ b/language/resource.language.nb_no/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.nl_nl/strings.po
+++ b/language/resource.language.nl_nl/strings.po
@@ -1987,3 +1987,7 @@ msgstr "Recent toegevoegd"
 msgctxt "#31999"
 msgid "Resolution"
 msgstr "Resolutie"
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.pl_pl/strings.po
+++ b/language/resource.language.pl_pl/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.pt_br/strings.po
+++ b/language/resource.language.pt_br/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.pt_pt/strings.po
+++ b/language/resource.language.pt_pt/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ro_ro/strings.po
+++ b/language/resource.language.ro_ro/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ru_ru/strings.po
+++ b/language/resource.language.ru_ru/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.si_lk/strings.po
+++ b/language/resource.language.si_lk/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sk_sk/strings.po
+++ b/language/resource.language.sk_sk/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sl_si/strings.po
+++ b/language/resource.language.sl_si/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sq_al/strings.po
+++ b/language/resource.language.sq_al/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sr_rs/strings.po
+++ b/language/resource.language.sr_rs/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sr_rs@latin/strings.po
+++ b/language/resource.language.sr_rs@latin/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.sv_se/strings.po
+++ b/language/resource.language.sv_se/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.szl/strings.po
+++ b/language/resource.language.szl/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.ta_in/strings.po
+++ b/language/resource.language.ta_in/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.te_in/strings.po
+++ b/language/resource.language.te_in/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.tg_tj/strings.po
+++ b/language/resource.language.tg_tj/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.th_th/strings.po
+++ b/language/resource.language.th_th/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.tr_tr/strings.po
+++ b/language/resource.language.tr_tr/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.uk_ua/strings.po
+++ b/language/resource.language.uk_ua/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.uz_uz/strings.po
+++ b/language/resource.language.uz_uz/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.vi_vn/strings.po
+++ b/language/resource.language.vi_vn/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.zh_cn/strings.po
+++ b/language/resource.language.zh_cn/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""

--- a/language/resource.language.zh_tw/strings.po
+++ b/language/resource.language.zh_tw/strings.po
@@ -1987,3 +1987,7 @@ msgstr ""
 msgctxt "#31999"
 msgid "Resolution"
 msgstr ""
+
+msgctxt "#32000"
+msgid "Visible in Master mode only"
+msgstr ""


### PR DESCRIPTION
There are different situations which may require to hide main menu items in home screen (e.g. content which is not suitable for chlidren). With this pull request it becomes possible to show/hide main menu items in home screen based on master mode.

If "Master" flag is not set the item is always visible (default).
If "Master" flag is set and master mode is enabled the item is visible.
If "Master" flag is set and master mode is disabled the item is hidden.