### PR TITLE
support kodi v19

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -8,7 +8,6 @@
     <import addon="xbmc.gui" version="5.15.0"/>
 	  <import addon="script.favourites" version="7.1.1"/>
 	  <import addon="service.library.data.provider" version="0.3.2"/>
-	  <import addon="script.randomandlastitems" version="2.2.2"/>
   </requires>
   <extension
     point="xbmc.gui.skin"

--- a/addon.xml
+++ b/addon.xml
@@ -5,7 +5,7 @@
   name="Xonfluence"
   provider-name="Helly">
   <requires>
-    <import addon="xbmc.gui" version="5.14.0"/>
+    <import addon="xbmc.gui" version="5.15.0"/>
 	  <import addon="script.favourites" version="7.1.1"/>
 	  <import addon="service.skin.widgets" version="0.0.33"/>
 	  <import addon="service.library.data.provider" version="0.3.2"/>

--- a/addon.xml
+++ b/addon.xml
@@ -7,7 +7,6 @@
   <requires>
     <import addon="xbmc.gui" version="5.15.0"/>
 	  <import addon="script.favourites" version="7.1.1"/>
-	  <import addon="service.skin.widgets" version="0.0.33"/>
 	  <import addon="service.library.data.provider" version="0.3.2"/>
 	  <import addon="script.randomandlastitems" version="2.2.2"/>
   </requires>


### PR DESCRIPTION
Hi, please merge in the upstream

Reason:

To support python 3, to work in kodi 19. Otherwise the addon cannot run, and cannot be enabled.

More details, see:

https://forum.kodi.tv/showthread.php?tid=346302&pid=2960872#pid2960872